### PR TITLE
Add support for openssl for android on Qt5.15.x

### DIFF
--- a/Dockerfile_5.x
+++ b/Dockerfile_5.x
@@ -60,6 +60,10 @@ ENV ANDROID_NDK_ROOT=/opt/android-sdk/ndk/21.4.7075529
 
 RUN \
     cd /opt && \
+    git clone --verbose --depth 1 https://github.com/KDAB/android_openssl
+
+RUN \
+    cd /opt && \
     tar xvfp /root/Qt-arm64-$QTVER.tar.xz && \
     rm /root/Qt-arm64-$QTVER.tar.xz
 
@@ -90,3 +94,4 @@ RUN \
 ENV PATH="${PATH}:/opt/Qt-$TARGETARCH-$QTVER/bin:/opt/Qt-$TARGETARCH-$QTVER/libexec"
 ENV QT_HOST_PATH="/opt/Qt-$TARGETARCH-$QTVER/"
 ENV QT_PLUGIN_PATH="/opt/Qt-$TARGETARCH-$QTVER/plugins"
+ENV OPENSSL_ROOT_DIR="/opt/android_openssl/ssl_1.1"

--- a/build_5.15.2.sh
+++ b/build_5.15.2.sh
@@ -54,6 +54,7 @@ set -e
 
 version=5.15.2
 
+git clone --verbose --depth 1 https://github.com/KDAB/android_openssl /opt/android-openssl
 git clone --verbose --depth 1 --branch v$version https://code.qt.io/qt/qt5.git
 cd qt5
 perl init-repository --module-subset=default,-qtwebengine
@@ -61,7 +62,7 @@ cd ..
 
 mkdir build
 cd build
-../qt5/configure -opensource -confirm-license -release -skip webengine -nomake tests -nomake examples -android-ndk $ANDROID_NDK_ROOT -android-sdk $ANDROID_SDK_ROOT -no-warnings-are-errors -xplatform android-clang -prefix /opt/Qt-android-$version -disable-rpath -android-ndk-host linux-x86_64
+../qt5/configure -opensource -confirm-license -release -skip webengine -nomake tests -nomake examples -android-ndk $ANDROID_NDK_ROOT -android-sdk $ANDROID_SDK_ROOT -no-warnings-are-errors -xplatform android-clang -prefix /opt/Qt-android-$version -disable-rpath -android-ndk-host linux-x86_64 --recheck -openssl-runtime -I /opt/android-openssl/ssl_1.1/include
 make -j $(($(nproc)+4))
 make install
 cp config.summary /opt/Qt-android-$version

--- a/build_5.15.8.sh
+++ b/build_5.15.8.sh
@@ -54,6 +54,7 @@ set -e
 
 version=5.15.8-lts-lgpl
 
+git clone --verbose --depth 1 https://github.com/KDAB/android_openssl /opt/android-openssl
 git clone --verbose --depth 1 --branch v$version https://code.qt.io/qt/qt5.git
 cd qt5
 perl init-repository --module-subset=default,-qtwebengine
@@ -61,7 +62,7 @@ cd ..
 
 mkdir build
 cd build
-../qt5/configure -opensource -confirm-license -release -skip webengine -nomake tests -nomake examples -android-ndk $ANDROID_NDK_ROOT -android-sdk $ANDROID_SDK_ROOT -no-warnings-are-errors -xplatform android-clang -prefix /opt/Qt-android-$version -disable-rpath -android-ndk-host linux-x86_64
+../qt5/configure -opensource -confirm-license -release -skip webengine -nomake tests -nomake examples -android-ndk $ANDROID_NDK_ROOT -android-sdk $ANDROID_SDK_ROOT -no-warnings-are-errors -xplatform android-clang -prefix /opt/Qt-android-$version -disable-rpath -android-ndk-host linux-x86_64 --recheck -openssl-runtime -I /opt/android-openssl/ssl_1.1/include
 make -j $(($(nproc)+4))
 make install
 cp config.summary /opt/Qt-android-$version


### PR DESCRIPTION
This patch adds the support for OpenSSL for Android to the Qt5.15.2 and Qt5.15.18 images, using the `-openssl-runtime` switch.